### PR TITLE
Fix map tile cache not working on windows for non ASCII cachefolder

### DIFF
--- a/qgeotiledmappingmanagerenginegooglemaps.cpp
+++ b/qgeotiledmappingmanagerenginegooglemaps.cpp
@@ -62,7 +62,7 @@ QGeoTiledMappingManagerEngineGooglemaps::QGeoTiledMappingManagerEngineGooglemaps
     setTileFetcher(fetcher);
 
     if (parameters.contains(QStringLiteral("googlemaps.cachefolder")))
-        m_cacheDirectory = parameters.value(QStringLiteral("googlemaps.cachefolder")).toString().toLatin1();
+        m_cacheDirectory = parameters.value(QStringLiteral("googlemaps.cachefolder")).toString();
 
     const int szCache = 100 * 1024 * 1024;
 #if QT_VERSION < QT_VERSION_CHECK(5,6,0)


### PR DESCRIPTION
This is a similar issue than the one I had a year ago syncing with cloud storage on windows, it is caused by my non ASCII username under windows (Jérémie). More details in the commit message itself.

I did test the fix with subsurface 4.7.8 I now have map images being cached... So would be great if the fork used for Subsurface build could integrate this fix.

For the little story, I was never using subsurface offline up to now so never realized the issue, until I went on a dive trip out of any kind of internet coverage and got surprised that I could not see map for the dive sites I already had visited...